### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,3 +1,6 @@
+permissions:
+  contents: read
+  actions: write
 name: Rust
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/minikin/zephyrite/security/code-scanning/1](https://github.com/minikin/zephyrite/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow. We can either add it at the root level (applying to all jobs) or directly to the `test` job. Since the workflow does not require write permissions beyond uploading artifacts and coverage reports, we can set minimal permissions: `contents: read` and `actions: write` (used for uploading artifacts). By explicitly defining these permissions, we adhere to the principle of least privilege.

The changes will involve adding a `permissions` block at the top of the workflow file, under the `name` field.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
